### PR TITLE
Allow optional plugin prefix, adds support for multi instance monitoring 

### DIFF
--- a/memcached_
+++ b/memcached_
@@ -181,8 +181,9 @@ $graphs{evictions} = {
 
 if (defined $ARGV[0] && $ARGV[0] eq 'config') {
 
-    $0 =~ /memcached_(.+)*/;
-    my $plugin = $1;
+    $0 =~ /(?:([^\/]+)_)?memcached_(.+)*/;
+    my $prefix = $1 ? $1 : '';
+    my $plugin = $2;
 
     die 'Unknown Plugin Specified: ' . ($plugin ? $plugin : '') unless $graphs{$plugin};
 
@@ -190,8 +191,8 @@ if (defined $ARGV[0] && $ARGV[0] eq 'config') {
     fetch_stats();
 
     # Now lets go ahead and print out our config.
-	do_config($plugin);
-	exit 0;
+    do_config($prefix, $plugin);
+    exit 0;
 }
 
 ##
@@ -318,8 +319,8 @@ sub print_root_output {
 ##
 
 sub do_config {
-    my ($plugin) = (@_);
-    print_root_config($plugin);
+    my ($prefix, $plugin) = (@_);
+    print_root_config($prefix, $plugin);
 
     return;
 }
@@ -329,7 +330,7 @@ sub do_config {
 ##
 
 sub print_root_config {
-    my ($plugin) = (@_);
+    my ($prefix, $plugin) = (@_);
 
     die 'Unknown Plugin Specified: ' . ($plugin ? $plugin : '') unless $graphs{$plugin};
 
@@ -340,7 +341,11 @@ sub print_root_config {
     #print "graph memcached_$plugin\n";
 
     while ( my ($key, $value) = each(%graphconf)) {
-        print "graph_$key $value\n";
+        if ($key eq 'title') {
+            print "graph_$key " . ucfirst($prefix) . " $value\n";
+        } else {
+            print "graph_$key $value\n";
+        }
     }
 
     foreach my $dsrc (@{$graph->{datasrc}}) {


### PR DESCRIPTION
Now it's possible to add a prefix to the symbolic link eg:

userdata_memcached_commands
filedetails_memcached_commands
.. etc

You can then specify port/host for each instance in plugin-conf.d
